### PR TITLE
feat(server): add rate limiting mechanism with configurable parameters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 PORT=4981
 LOG_LEVEL=info
 APP_ENV=development
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_WINDOW_MS=60000
+RATE_LIMIT_MAX_REQUESTS=30
 
 # Gemini Configuration
 # To get these values, visit https://gemini.google.com and log in

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ docker run -d -p 4981:4981 \
   -e GEMINI_REFRESH_INTERVAL=30 \
   -e GEMINI_MAX_RETRIES=3 \
   -e APP_ENV=production \
+  -e RATE_LIMIT_ENABLED=true \
+  -e RATE_LIMIT_WINDOW_MS=60000 \
+  -e RATE_LIMIT_MAX_REQUESTS=10 \
   -v ./cookies:/home/appuser/.cookies \
   --tmpfs /tmp:rw,size=512m \
   --tmpfs /home/appuser/.cache:rw,size=256m \
@@ -121,6 +124,9 @@ cd gemini-web-to-api
    GEMINI_REFRESH_INTERVAL=30
    GEMINI_MAX_RETRIES=3
    APP_ENV=production
+   RATE_LIMIT_ENABLED=true
+   RATE_LIMIT_WINDOW_MS=60000
+   RATE_LIMIT_MAX_REQUESTS=10
    ```
 
 **Step 3 — Run**
@@ -171,6 +177,9 @@ Your Gemini Web To API is running at `http://localhost:4981` 🎉
 | `GEMINI_REFRESH_INTERVAL` | ❌ No    | `30`    | Cookie rotation interval (minutes)                   |
 | `GEMINI_MAX_RETRIES`      | ❌ No    | `3`     | Max retry attempts when an API call fails            |
 | `PORT`                    | ❌ No    | `4981`  | Server port                                          |
+| `RATE_LIMIT_ENABLED`      | ❌ No    | `false` | Enable or disable rate limiting                      |
+| `RATE_LIMIT_WINDOW_MS`    | ❌ No    | `60000` | Rate limit time window in milliseconds               |
+| `RATE_LIMIT_MAX_REQUESTS` | ❌ No    | `10`    | Maximum number of requests allowed per time window   |
 
 ### Configuration Priority
 

--- a/internal/commons/configs/configs.go
+++ b/internal/commons/configs/configs.go
@@ -12,8 +12,15 @@ type Config struct {
 	Gemini GeminiConfig
 	Claude ClaudeConfig
 	OpenAI OpenAIConfig
-	Server ServerConfig	
-	LogLevel string
+	Server    ServerConfig
+	RateLimit RateLimitConfig
+	LogLevel  string
+}
+
+type RateLimitConfig struct {
+	Enabled     bool
+	WindowMs    int
+	MaxRequests int
 }
 
 type GeminiConfig struct {
@@ -58,6 +65,11 @@ func New() (*Config, error) {
 	
 	// General
 	cfg.LogLevel = getEnv("LOG_LEVEL", defaultLogLevel)
+
+	// Rate Limit
+	cfg.RateLimit.Enabled = getEnvBool("RATE_LIMIT_ENABLED", false)
+	cfg.RateLimit.WindowMs = getEnvInt("RATE_LIMIT_WINDOW_MS", 60000)
+	cfg.RateLimit.MaxRequests = getEnvInt("RATE_LIMIT_MAX_REQUESTS", 10)
 
 	// Gemini
 	cfg.Gemini.Secure1PSID = os.Getenv("GEMINI_1PSID")
@@ -125,4 +137,14 @@ func getEnvInt(key string, defaultValue int) int {
 	return value
 }
 
-
+func getEnvBool(key string, defaultValue bool) bool {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+	value, err := strconv.ParseBool(valueStr)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,19 +3,21 @@ package server
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"gemini-web-to-api/internal/commons/configs"
 
 	"github.com/gofiber/contrib/v3/swaggo"
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/cors"
+	"github.com/gofiber/fiber/v3/middleware/limiter"
 	"github.com/gofiber/fiber/v3/middleware/recover"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 )
 
 // New creates a new Fiber app instance
-func NewGeminiWebToAPI(log *zap.Logger) *fiber.App {
+func NewGeminiWebToAPI(log *zap.Logger, cfg *configs.Config) *fiber.App {
 	app := fiber.New(fiber.Config{
 		AppName: "Gemini Web To API",
 	})
@@ -28,6 +30,13 @@ func NewGeminiWebToAPI(log *zap.Logger) *fiber.App {
 	}))
 
 	app.Use(recover.New())
+
+	if cfg.RateLimit.Enabled {
+		app.Use(limiter.New(limiter.Config{
+			Max:        cfg.RateLimit.MaxRequests,
+			Expiration: time.Duration(cfg.RateLimit.WindowMs) * time.Millisecond,
+		}))
+	}
 
 	// Swagger UI — gofiber/contrib/v3/swaggo (Fiber v3 compatible)
 	app.Get("/swagger/*", swaggo.HandlerDefault)


### PR DESCRIPTION
Introduce rate limiting functionality to control the number of requests per time window. Adds new configuration options for enabling/disabling rate limiting, setting time windows, and defining maximum requests. Updates server initialization to conditionally apply rate limiting middleware based on configuration settings.

New environment variables:
- RATE_LIMIT_ENABLED: enable/disable rate limiting
- RATE_LIMIT_WINDOW_MS: time window in milliseconds
- RATE_LIMIT_MAX_REQUESTS: max requests per window

Also adds getEnvBool helper function for boolean environment variables.