### PR TITLE
Fix #69: Claude Code v2.x compatibility by supporting structured system content

### DIFF
--- a/LOCAL.md
+++ b/LOCAL.md
@@ -1,0 +1,2 @@
+docker compose down
+docker compose up --build

--- a/LOCAL.md
+++ b/LOCAL.md
@@ -1,2 +1,0 @@
-docker compose down
-docker compose up --build

--- a/internal/modules/claude/claude_controller.go
+++ b/internal/modules/claude/claude_controller.go
@@ -158,7 +158,7 @@ func (h *ClaudeController) HandleCountTokens(c fiber.Ctx) error {
 	}
 
 	// Simple estimation
-	totalChars := len(req.System)
+	totalChars := len(req.System.Text)
 	for _, m := range req.Messages {
 		totalChars += len(m.Content)
 	}

--- a/internal/modules/claude/claude_service.go
+++ b/internal/modules/claude/claude_service.go
@@ -39,7 +39,7 @@ func (s *ClaudeService) GenerateMessage(ctx context.Context, req dto.MessageRequ
 	}
 
 	// Logic: Build Prompt
-	prompt := common.BuildPromptFromMessages(req.Messages, req.System)
+	prompt := common.BuildPromptFromMessages(req.Messages, req.System.Text)
 	if prompt == "" {
 		return nil, fmt.Errorf("no valid content in messages")
 	}

--- a/internal/modules/claude/dto/claude_dto.go
+++ b/internal/modules/claude/dto/claude_dto.go
@@ -7,13 +7,13 @@ import (
 
 // MessageRequest represents the specialized Claude request body
 type MessageRequest struct {
-	Model     string           `json:"model"`
-	MaxTokens int              `json:"max_tokens"`
-	Messages  []models.Message `json:"messages"`
-	System    string           `json:"system,omitempty"`
-	Stream    bool             `json:"stream,omitempty"`
-	Tools     []Tool           `json:"tools,omitempty"`
-	ToolChoice *ToolChoice     `json:"tool_choice,omitempty"`
+	Model     string           			`json:"model"`
+	MaxTokens int              			`json:"max_tokens"`
+	Messages  []models.Message 			`json:"messages"`
+	System    AnthropicSystemContent    `json:"system,omitempty"`
+	Stream    bool             			`json:"stream,omitempty"`
+	Tools     []Tool           			`json:"tools,omitempty"`
+	ToolChoice *ToolChoice     			`json:"tool_choice,omitempty"`
 }
 
 // Tool represents a tool available to the model

--- a/internal/modules/claude/dto/system.go
+++ b/internal/modules/claude/dto/system.go
@@ -1,0 +1,41 @@
+package dto
+
+import "encoding/json"
+
+type AnthropicSystemContent struct {
+    Text string
+}
+
+func (s *AnthropicSystemContent) UnmarshalJSON(data []byte) error {
+
+    // string
+    var str string
+    if err := json.Unmarshal(data, &str); err == nil {
+        s.Text = str
+        return nil
+    }
+
+    // Claude Code format
+    var arr []struct {
+        Type string `json:"type"`
+        Text string `json:"text"`
+    }
+
+    if err := json.Unmarshal(data, &arr); err == nil {
+
+        for _, v := range arr {
+
+            if v.Type == "text" {
+                if s.Text != "" {
+                    s.Text += "\n"
+                }
+                s.Text += v.Text
+            }
+
+        }
+
+        return nil
+    }
+
+    return nil
+}


### PR DESCRIPTION
## Summary

This PR fixes compatibility with recent versions of Claude Code.

Claude Code v2.x sends the `system` field as structured content blocks instead of a plain string. The current implementation expects `system` to be a string, causing request binding to fail with:

```text
json: cannot unmarshal array into Go struct field MessageRequest.system of type string
```

As a result, requests return:

```text
400 Invalid JSON body
```

## Changes

- Added support for structured `system` content blocks.
- Preserved support for the existing string-based `system` field.
- Updated usages of `req.System` to use the normalized text value.

## Backward Compatibility

This change is fully backward compatible.

Supported formats:

### Legacy

```json
{
  "system": "You are a helpful assistant."
}
```

### Structured Content

```json
{
  "system": [
    {
      "type": "text",
      "text": "You are a helpful assistant."
    }
  ]
}
```

## Testing

Verified using:

- Claude Code v2.1.218
- Interactive mode (`claude`)
- One-shot mode (`claude -p "Hello"`)

All requests are now processed successfully.

Fixes #69